### PR TITLE
fix: Attempting to fix GH timeout

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,6 +70,7 @@
       [
         "@semantic-release/github",
         {
+          "successComment": false,
           "failTitle": false
         }
       ]


### PR DESCRIPTION
There's some sort of API timeout, as it tries to read all commits in the log, so I think maybe setting `successComment` to false fixed this in the past.