### PR TITLE
feat: Adding Overworld Functionality

### DIFF
--- a/ui/src/assets/IconSave.vue
+++ b/ui/src/assets/IconSave.vue
@@ -1,0 +1,8 @@
+<template>
+	<BaseIcon :icon="SVGIcon" />
+</template>
+
+<script setup lang="ts">
+import SVGIcon from "@material-symbols/svg-400/outlined/save.svg";
+import BaseIcon from "@/components/BaseIcon.vue";
+</script>

--- a/ui/src/assets/IconUploadFile.vue
+++ b/ui/src/assets/IconUploadFile.vue
@@ -1,0 +1,8 @@
+<template>
+	<BaseIcon :icon="SVGIcon" />
+</template>
+
+<script setup lang="ts">
+import SVGIcon from "@material-symbols/svg-400/outlined/upload_file.svg";
+import BaseIcon from "@/components/BaseIcon.vue";
+</script>

--- a/ui/src/assets/theme/tree/index.js
+++ b/ui/src/assets/theme/tree/index.js
@@ -1,18 +1,14 @@
 export default {
 	root: {
 		class: [
-			"relative",
-
-			// Space
-			"p-1.5",
-
 			// Shape
 			"rounded-md",
 
 			// Color
 			"bg-surface-0 dark:bg-surface-800",
 			"text-surface-700 dark:text-white/80",
-			"ring-1 ring-surface-200 dark:ring-surface-700",
+			"border-0 ring-1 ring-inset ring-gray-b dark:ring-surface-700 focus-visible:outline-none",
+			"[&_[data-pc-name=pcfilter]]:w-full",
 		],
 	},
 	wrapper: {
@@ -28,9 +24,9 @@ export default {
 		],
 	},
 	node: {
-		class: ["p-[2px]", "rounded-md", "focus:outline-none focus:outline-offset-0 focus:ring-2 focus:ring-inset focus:ring-primary-500 dark:focus:ring-primary-400"],
+		class: ["p-1", "text-sm", "rounded-md focus-visible:outline-none"],
 	},
-	content: ({ context, props }) => ({
+	nodeContent: ({ context, props }) => ({
 		class: [
 			// Flex and Alignment
 			"flex items-center",
@@ -39,28 +35,25 @@ export default {
 			"rounded-md",
 
 			// Spacing
-			"p-2",
+			"p-2 gap-2",
 
 			// Colors
-			"text-surface-700 dark:text-surface-0",
-			{
-				"bg-surface-100 text-primary-500 dark:bg-surface-300/10 dark:text-primary-400": context.selected,
+			"text-surface-600 dark:text-white/70", {
+				"bg-sky-200 font-semibold": context.selected,
 			},
 
 			// States
 			{
-				"hover:bg-surface-200 dark:hover:bg-surface-400/10": props.selectionMode == "single" || props.selectionMode == "multiple",
+				"hover:bg-surface-50 dark:hover:bg-surface-700/40": (props.selectionMode == "single" || props.selectionMode == "multiple") && !context.selected,
 			},
 
 			// Transition
-			"transition-shadow duration-200",
-
-			{
+			"transition-shadow duration-200", {
 				"cursor-pointer select-none": props.selectionMode == "single" || props.selectionMode == "multiple",
 			},
 		],
 	}),
-	toggler: ({ context }) => ({
+	nodeToggleButton: ({ context }) => ({
 		class: [
 			// Flex and Alignment
 			"inline-flex items-center justify-center",
@@ -68,25 +61,19 @@ export default {
 			// Shape
 			"border-0 rounded-full",
 
-			// Size and Spacing
-			"mr-2",
-			"w-6 h-6",
-
-			// Spacing
-			"mr-2",
+			// Size
+			"size-6",
 
 			// Colors
-			"text-surface-500",
-			"bg-transparent",
-			{
-				invisible: context.leaf,
+			"bg-transparent", {
+				"text-surface-500 dark:text-white": !context.selected,
+				"text-primary-600 dark:text-white": context.selected,
+				"hidden pr-2": context.leaf,
 			},
 
 			// States
-			"hover:text-surface-700 dark:hover:text-white/80",
-			"hover:bg-surface-100 dark:hover:bg-surface-800/80",
-			"focus:outline-none focus:outline-offset-0 focus:ring-1 focus:ring-inset",
-			"focus:ring-primary-500 dark:focus:ring-primary-400",
+			"hover:bg-surface-200/20 dark:hover:bg-surface-500/20",
+			"focus:outline-none focus:outline-offset-0 focus:ring focus:ring-primary-400/50 dark:focus:ring-primary-300/50",
 
 			// Transition
 			"transition duration-200",
@@ -95,136 +82,20 @@ export default {
 			"cursor-pointer select-none",
 		],
 	}),
-	togglericon: {
-		class: [
-			// Size
-			"w-4 h-4",
-
-			// Color
-			"text-surface-500 dark:text-white/70",
-		],
-	},
-	checkboxcontainer: {
-		class: "mr-2",
-	},
-	checkbox: ({ context, props }) => ({
-		class: [
-			"relative",
-			// Alignment
-			"flex",
-			"items-center",
-			"justify-center",
-
-			// Size
-			"w-4",
-			"h-4",
-
-			// Shape
-			"rounded",
-			"border",
-
-			// Colors
-			"text-surface-600",
-			{
-				"border-surface-300 bg-surface-0 dark:border-surface-700 dark:bg-surface-900": !context.checked,
-				"border-primary-500 bg-primary-500 dark:border-primary-400 dark:bg-primary-400": context.checked,
-			},
-
-			// States
-			"focus:outline-none focus:outline-offset-0",
-			{
-				"ring-2 ring-primary-500 dark:ring-primary-400": !props.disabled && context.focused,
-				"cursor-default opacity-60": props.disabled,
-			},
-
-			// Transitions
-			"transition-colors",
-			"duration-200",
-		],
-	}),
-	checkboxicon: {
-		class: [
-			// Font
-			"text-normal",
-
-			// Size
-			"w-3",
-			"h-3",
-
-			// Colors
-			"text-white dark:text-surface-900",
-
-			// Transitions
-			"transition-all",
-			"duration-200",
-		],
-	},
-	nodeicon: {
+	nodeIcon: ({ context }) => ({
 		class: [
 			// Space
-			"mr-2",
+			{
+				hidden: context.leaf,
+			}, "mr-2",
 
 			// Color
-			"text-surface-600 dark:text-white/70",
-		],
-	},
-	subgroup: {
+			"text-surface-600 dark:text-white/70"],
+	}),
+	nodeChildren: {
 		class: ["m-0 list-none p-0 pl-2 mt-1"],
 	},
-	filtercontainer: {
-		class: [
-			"relative block",
-
-			// Space
-			"mb-2",
-
-			// Size
-			"w-full",
-		],
-	},
-	input: {
-		class: [
-			"relative",
-
-			// Font
-			"font-sans leading-6",
-			"sm:text-sm",
-
-			// Spacing
-			"m-0",
-			"py-1.5 px-3 pr-10",
-
-			// Size
-			"w-full",
-
-			// Shape
-			"rounded-md",
-
-			// Colors
-			"text-surface-900 dark:text-surface-0",
-			"placeholder:text-surface-400 dark:placeholder:text-surface-500",
-			"bg-surface-0 dark:bg-surface-900",
-			"ring-1 ring-inset ring-surface-300 dark:ring-surface-700 ring-offset-0",
-
-			// States
-			"hover:border-primary-500 dark:hover:border-primary-400",
-			"focus:outline-none focus:outline-offset-0 focus:ring-2 focus:ring-inset focus:ring-primary-500 dark:focus:ring-primary-400",
-
-			// Transition & Misc
-			"appearance-none",
-			"transition-colors duration-200",
-		],
-	},
-	loadingicon: {
+	loadingIcon: {
 		class: ["text-surface-500 dark:text-surface-0/70", "absolute top-[50%] right-[50%] -mt-2 -mr-2 animate-spin"],
-	},
-	searchicon: {
-		class: [
-			// Position
-			"absolute top-1/2 -mt-2 right-3",
-
-			// Color
-			"text-surface-600 dark:hover:text-white/70",
-		],
 	},
 };

--- a/ui/src/assets/theme/treeselect/index.js
+++ b/ui/src/assets/theme/treeselect/index.js
@@ -3,28 +3,35 @@ export default {
 		class: [
 			// Display and Position
 			"inline-flex",
-			"relative",
+			"relative max-h-8",
 
 			// Shape
-			"w-full md:w-56",
 			"rounded-md",
-			"shadow-sm",
 
 			// Color and Background
 			"bg-surface-0 dark:bg-surface-900",
-
-			// States
-			{
-				"ring-1 ring-inset ring-surface-300 dark:ring-surface-700": !state.focused,
-				"ring-2 ring-inset ring-primary-500 dark:ring-primary-400": state.focused,
+			"border", {
+				"border-surface-300 dark:border-surface-600": !props.invalid,
 			},
 
-			// Misc
-			"cursor-default",
-			"select-none",
+			// Invalid State
 			{
+				"border-red-500 dark:border-red-400": props.invalid,
+			},
+
+			// Transitions
+			"transition-all",
+			"duration-200",
+
+			// States
+			"ring-1 ring-inset ring-gray-b dark:ring-surface-700",
+
+			// Misc
+			"cursor-pointer",
+			"select-none", {
 				"opacity-60": props.disabled,
 				"pointer-events-none": props.disabled,
+				"cursor-default": props.disabled,
 			},
 		],
 	}),
@@ -33,10 +40,10 @@ export default {
 	},
 	label: {
 		class: [
-			"block leading-5",
+			"block leading-[normal]",
 
 			// Space
-			"py-1.5 px-3",
+			"py-1.5 px-2 text-sm",
 
 			// Color
 			"text-surface-800 dark:text-white/80",
@@ -48,11 +55,8 @@ export default {
 			"overflow-hidden whitespace-nowrap cursor-pointer overflow-ellipsis",
 		],
 	},
-	trigger: {
+	dropdown: {
 		class: [
-			//Font
-			"sm:text-sm",
-
 			// Flexbox
 			"flex items-center justify-center",
 			"shrink-0",
@@ -73,20 +77,20 @@ export default {
 		class: [
 			// Position
 			"absolute top-0 left-0",
-			"mt-2",
 
 			// Shape
-			"border-0",
+			"border-0 dark:border",
 			"rounded-md",
 			"shadow-md",
 
 			// Color
-			"bg-surface-0 dark:bg-surface-800",
+			"bg-white dark:bg-surface-800",
 			"text-surface-800 dark:text-white/80",
-			"ring-1 ring-inset ring-surface-300 dark:ring-surface-700",
+			"dark:border-surface-700",
+			"ring-1 ring-inset ring-gray-b dark:ring-surface-700",
 		],
 	},
-	wrapper: {
+	treeContainer: {
 		class: [
 			// Sizing
 			"max-h-[200px]",
@@ -94,228 +98,6 @@ export default {
 			// Misc
 			"overflow-auto",
 		],
-	},
-	tree: {
-		root: {
-			class: [
-				"relative",
-
-				// Space
-				"p-1.5",
-			],
-		},
-		wrapper: {
-			class: ["overflow-auto"],
-		},
-		container: {
-			class: [
-				// Spacing
-				"m-0 p-0",
-
-				// Misc
-				"list-none overflow-auto",
-			],
-		},
-		node: {
-			class: ["p-[2px]", "rounded-md", "focus:outline-none focus:outline-offset-0 focus:ring-2 focus:ring-inset focus:ring-primary-500 dark:focus:ring-primary-400"],
-		},
-		content: ({ context, props }) => ({
-			class: [
-				// Flex and Alignment
-				"flex items-center",
-
-				// Shape
-				"rounded-md",
-
-				// Spacing
-				"p-2",
-
-				// Colors
-				"text-surface-700 dark:text-surface-0",
-				{
-					"bg-surface-100 text-primary-500 dark:bg-surface-300/10 dark:text-primary-400": context.selected,
-				},
-
-				// States
-				{
-					"hover:bg-surface-200 dark:hover:bg-surface-400/10": props.selectionMode == "single" || props.selectionMode == "multiple",
-				},
-
-				// Transition
-				"transition-shadow duration-200",
-
-				{
-					"cursor-pointer select-none": props.selectionMode == "single" || props.selectionMode == "multiple",
-				},
-			],
-		}),
-		toggler: ({ context }) => ({
-			class: [
-				// Flex and Alignment
-				"inline-flex items-center justify-center",
-
-				// Shape
-				"border-0 rounded-full",
-
-				// Size and Spacing
-				"mr-2",
-				"w-6 h-6",
-
-				// Spacing
-				"mr-2",
-
-				// Colors
-				"text-surface-500",
-				"bg-transparent",
-				{
-					invisible: context.leaf,
-				},
-
-				// States
-				"hover:text-surface-700 dark:hover:text-white/80",
-				"hover:bg-surface-100 dark:hover:bg-surface-800/80",
-				"focus:outline-none focus:outline-offset-0 focus:ring-1 focus:ring-inset",
-				"focus:ring-primary-500 dark:focus:ring-primary-400",
-
-				// Transition
-				"transition duration-200",
-
-				// Misc
-				"cursor-pointer select-none",
-			],
-		}),
-		togglericon: {
-			class: [
-				// Size
-				"w-4 h-4",
-
-				// Color
-				"text-surface-500 dark:text-white/70",
-			],
-		},
-		checkboxcontainer: {
-			class: "mr-2",
-		},
-		checkbox: ({ context, props }) => ({
-			class: [
-				"relative",
-				// Alignment
-				"flex",
-				"items-center",
-				"justify-center",
-
-				// Size
-				"w-4",
-				"h-4",
-
-				// Shape
-				"rounded",
-				"border",
-
-				// Colors
-				"text-surface-600",
-				{
-					"border-surface-300 bg-surface-0 dark:border-surface-700 dark:bg-surface-900": !context.checked,
-					"border-primary-500 bg-primary-500 dark:border-primary-400 dark:bg-primary-400": context.checked,
-				},
-
-				// States
-				"focus:outline-none focus:outline-offset-0",
-				{
-					"ring-2 ring-primary-500 dark:ring-primary-400": !props.disabled && context.focused,
-					"cursor-default opacity-60": props.disabled,
-				},
-
-				// Transitions
-				"transition-colors",
-				"duration-200",
-			],
-		}),
-		checkboxicon: {
-			class: [
-				// Font
-				"text-normal",
-
-				// Size
-				"w-3",
-				"h-3",
-
-				// Colors
-				"text-white dark:text-surface-900",
-
-				// Transitions
-				"transition-all",
-				"duration-200",
-			],
-		},
-		nodeicon: {
-			class: [
-				// Space
-				"mr-2",
-
-				// Color
-				"text-surface-600 dark:text-white/70",
-			],
-		},
-		subgroup: {
-			class: ["m-0 list-none p-0 pl-2 mt-1"],
-		},
-		filtercontainer: {
-			class: [
-				"relative block",
-
-				// Space
-				"mb-2",
-
-				// Size
-				"w-full",
-			],
-		},
-		input: {
-			class: [
-				"relative",
-
-				// Font
-				"font-sans leading-6",
-				"sm:text-sm",
-
-				// Spacing
-				"m-0",
-				"py-1.5 px-3 pr-10",
-
-				// Size
-				"w-full",
-
-				// Shape
-				"rounded-md",
-
-				// Colors
-				"text-surface-900 dark:text-surface-0",
-				"placeholder:text-surface-400 dark:placeholder:text-surface-500",
-				"bg-surface-0 dark:bg-surface-900",
-				"ring-1 ring-inset ring-surface-300 dark:ring-surface-700 ring-offset-0",
-
-				// States
-				"hover:border-primary-500 dark:hover:border-primary-400",
-				"focus:outline-none focus:outline-offset-0 focus:ring-2 focus:ring-inset focus:ring-primary-500 dark:focus:ring-primary-400",
-
-				// Transition & Misc
-				"appearance-none",
-				"transition-colors duration-200",
-			],
-		},
-		loadingicon: {
-			class: ["text-surface-500 dark:text-surface-0/70", "absolute top-[50%] right-[50%] -mt-2 -mr-2 animate-spin"],
-		},
-		searchicon: {
-			class: [
-				// Position
-				"absolute top-1/2 -mt-2 right-3",
-
-				// Color
-				"text-surface-600 dark:hover:text-white/70",
-			],
-		},
 	},
 	transition: {
 		enterFromClass: "opacity-0 scale-y-[0.8]",

--- a/ui/src/components/BaseDialog.vue
+++ b/ui/src/components/BaseDialog.vue
@@ -3,7 +3,9 @@
 		v-model:visible="show"
 		:modal="modal"
 		:content-class="bodyCls"
-		@hide="onClose"
+		:closable="false"
+		:close-on-escape="false"
+		@keydown.esc="onKeyEscape"
 	>
 		<template #header>
 			<slot name="header">
@@ -11,6 +13,13 @@
 					{{ title }}
 				</h2>
 			</slot>
+			<BaseButton
+				:icon="IconCancel"
+				:plain="true"
+				class="ml-auto !p-0 hover:fill-red-800"
+				icon-cls="size-5"
+				@click="onClickCloseButton"
+			/>
 		</template>
 		<template #default>
 			<slot name="body" />
@@ -37,7 +46,7 @@ import BaseButton from "@/components/BaseButton.vue";
 interface IProps {
 	title?: string;
 	modal?: boolean;
-  bodyCls?: string;
+	bodyCls?: string;
 }
 
 withDefaults(defineProps<IProps>(), {
@@ -45,17 +54,34 @@ withDefaults(defineProps<IProps>(), {
 	title: undefined,
 	bodyCls: undefined,
 });
-const emit = defineEmits(["close", "cancel"]);
+const emit = defineEmits(["close", "click-cancel"]);
 const show = defineModel<boolean>("modelValue", {
 	default: false,
 });
 
-function onCancel() {
+function close() {
 	show.value = false;
-	emit("cancel");
 }
 
-function onClose() {
-	emit("close");
+function cancel() {
+	close();
+	emit("click-cancel");
 }
+
+function onCancel() {
+	cancel();
+}
+
+function onKeyEscape() {
+	cancel();
+}
+
+function onClickCloseButton() {
+	cancel();
+}
+
+defineExpose({
+	close,
+	cancel,
+});
 </script>

--- a/ui/src/components/BaseTabs.vue
+++ b/ui/src/components/BaseTabs.vue
@@ -1,0 +1,38 @@
+<script setup lang="ts">
+interface IBaseTabs {
+	tabs: string[];
+}
+
+defineProps<IBaseTabs>();
+const selected = defineModel<string>("selected");
+
+function onClickTab(tab: string) {
+	selected.value = tab;
+}
+
+function getTabCls(tab: string) {
+	return {
+		"bg-sky-200 font-semibold": tab === selected.value,
+		"bg-gray-300": tab !== selected.value,
+	};
+}
+</script>
+
+<template>
+	<article class="flex flex-col overflow-hidden">
+		<section class="flex h-8">
+			<div
+				v-for="tab in tabs"
+				:key="tab"
+				class="flex h-full cursor-pointer items-center rounded-t border border-b-0 border-gray-b px-3 text-sm hover:bg-sky-200 [&:nth-child(n+2)]:border-l-0"
+				:class="getTabCls(tab)"
+				@click="onClickTab(tab)"
+			>
+				<span>{{ tab }}</span>
+			</div>
+		</section>
+		<section class="flex-1 overflow-auto rounded-r rounded-bl border border-gray-b p-2">
+			<slot name="content" />
+		</section>
+	</article>
+</template>

--- a/ui/src/components/FieldComboBox.vue
+++ b/ui/src/components/FieldComboBox.vue
@@ -18,7 +18,7 @@
 	</BaseField>
 </template>
 
-<script setup lang="ts" generic="T">
+<script setup lang="ts">
 import { computed, watch } from "vue";
 import PrimeDropdown from "primevue/select";
 import BaseField, { IBaseField } from "@/components/BaseField.vue";
@@ -26,7 +26,7 @@ import { IOption } from "@/types/components";
 import { isObject } from "@/utils/common";
 
 export interface IFieldComboBox extends IBaseField {
-	options?: IOption[] | T[];
+	options?: IOption[];
 	optionLabel?: string | ((data: any) => string) | undefined;
 	optionValue?: string | ((data: any) => any) | undefined;
 	disabled?: boolean;

--- a/ui/src/components/FieldComboBox.vue
+++ b/ui/src/components/FieldComboBox.vue
@@ -22,11 +22,10 @@
 import { computed, watch } from "vue";
 import PrimeDropdown from "primevue/select";
 import BaseField, { IBaseField } from "@/components/BaseField.vue";
-import { IOption } from "@/types/components";
 import { isObject } from "@/utils/common";
 
 export interface IFieldComboBox extends IBaseField {
-	options?: IOption[] | object[];
+	options?: any[];
 	optionLabel?: string | ((data: any) => string) | undefined;
 	optionValue?: string | ((data: any) => any) | undefined;
 	disabled?: boolean;
@@ -55,7 +54,7 @@ const model = computed({
 		emit("update:modelValue", props.valueOnly ? value : getSelected(value));
 	},
 });
-const selected = defineModel<IOption>("selected");
+const selected = defineModel<unknown>("selected");
 
 function getSelected(value = props.modelValue) {
 	const { optionValue } = props;

--- a/ui/src/components/FieldComboBox.vue
+++ b/ui/src/components/FieldComboBox.vue
@@ -26,7 +26,7 @@ import { IOption } from "@/types/components";
 import { isObject } from "@/utils/common";
 
 export interface IFieldComboBox extends IBaseField {
-	options?: IOption[];
+	options?: IOption[] | object[];
 	optionLabel?: string | ((data: any) => string) | undefined;
 	optionValue?: string | ((data: any) => any) | undefined;
 	disabled?: boolean;

--- a/ui/src/components/FieldComboBox.vue
+++ b/ui/src/components/FieldComboBox.vue
@@ -18,7 +18,7 @@
 	</BaseField>
 </template>
 
-<script setup lang="ts">
+<script setup lang="ts" generic="T">
 import { computed, watch } from "vue";
 import PrimeDropdown from "primevue/select";
 import BaseField, { IBaseField } from "@/components/BaseField.vue";
@@ -26,7 +26,7 @@ import { IOption } from "@/types/components";
 import { isObject } from "@/utils/common";
 
 export interface IFieldComboBox extends IBaseField {
-	options?: IOption[];
+	options?: IOption[] | T[];
 	optionLabel?: string | ((data: any) => string) | undefined;
 	optionValue?: string | ((data: any) => any) | undefined;
 	disabled?: boolean;

--- a/ui/src/components/FieldText.vue
+++ b/ui/src/components/FieldText.vue
@@ -2,6 +2,7 @@
 	<BaseField v-bind="$props">
 		<section class="relative flex-1">
 			<PrimeInputText
+				ref="libCmp"
 				v-model="modelValue"
 				:class="inputCls"
 				:type="type"
@@ -22,7 +23,7 @@
 </template>
 
 <script setup lang="ts">
-import { computed, InputTypeHTMLAttribute } from "vue";
+import { computed, InputTypeHTMLAttribute, onMounted, ref } from "vue";
 import PrimeInputText from "primevue/inputtext";
 import IconClear from "@/assets/IconClear.vue";
 import BaseButton from "@/components/BaseButton.vue";
@@ -37,6 +38,7 @@ interface IFieldText extends IBaseField {
 	 */
 	delay?: number;
 	inputWidth?: string;
+	autoFocus?: boolean;
 }
 
 const props = withDefaults(defineProps<IFieldText>(), {
@@ -48,6 +50,7 @@ const props = withDefaults(defineProps<IFieldText>(), {
 const emit = defineEmits(["inputEnd", "inputClear"]);
 const modelValue = defineModel<string>();
 let inputEndTimer: ReturnType<typeof setTimeout>;
+const libCmp = ref<InstanceType<typeof PrimeInputText>>();
 const clearVisible = computed(() => props.showClear && !!modelValue.value);
 const inputCls = computed(() => {
 	return {
@@ -65,4 +68,10 @@ function onKeyUp() {
 	clearTimeout(inputEndTimer);
 	inputEndTimer = setTimeout(() => emit("inputEnd"), props.delay);
 }
+
+onMounted(() => {
+	if (props.autoFocus) {
+		libCmp.value?.$el.focus();
+	}
+});
 </script>

--- a/ui/src/components/FieldTreeBox.vue
+++ b/ui/src/components/FieldTreeBox.vue
@@ -4,7 +4,7 @@ import PrimeTreeSelect from "primevue/treeselect";
 import BaseField, { IBaseField } from "@/components/BaseField.vue";
 import { ITreeOption } from "@/types/components";
 
-type IFieldTreeBoxSelection = Record<string, boolean>;
+export type IFieldTreeBoxSelection = Record<string, boolean>;
 
 export interface IFieldTreeBox extends IBaseField {
 	options?: ITreeOption<T>[];

--- a/ui/src/components/FieldTreeBox.vue
+++ b/ui/src/components/FieldTreeBox.vue
@@ -1,0 +1,66 @@
+<script setup lang="ts" generic="T extends object">
+import { computed } from "vue";
+import PrimeTreeSelect from "primevue/treeselect";
+import BaseField, { IBaseField } from "@/components/BaseField.vue";
+import { ITreeOption } from "@/types/components";
+
+type IFieldTreeBoxSelection = Record<string, boolean>;
+
+export interface IFieldTreeBox extends IBaseField {
+	options?: ITreeOption<T>[];
+	optionLabel?: string | undefined;
+	optionValue?: string | undefined;
+	disabled?: boolean;
+	showClear?: boolean;
+	valueOnly?: boolean;
+	modelValue?: string | IFieldTreeBoxSelection;
+}
+
+const props = withDefaults(defineProps<IFieldTreeBox>(), {
+	optionLabel: "label",
+	optionValue: "key",
+	valueOnly: true,
+	modelValue: undefined,
+	options: () => [],
+});
+const emit = defineEmits(["update:modelValue"]);
+const selected = defineModel<ITreeOption<T>>("selected");
+const model = computed({
+	get() {
+		const { modelValue } = props;
+		if (typeof modelValue === "string") {
+			// The TreeSelect expects a specific key-value pair, which is weird
+			return {
+				[modelValue]: true,
+			};
+		}
+		return modelValue;
+	},
+	set(value) {
+		emit("update:modelValue", value);
+		const selections = Object.keys(value ?? {});
+		selected.value = getSelected(props.options, selections[0]);
+	},
+});
+
+function getSelected(options: ITreeOption<T>[], value: string): ITreeOption<T> | undefined {
+	const { optionValue } = props;
+	return options.find((option) => {
+		if (option[optionValue as keyof typeof option] === value) {
+			return option;
+		}
+		else if (option.children) {
+			return getSelected(option.children, value);
+		}
+	});
+}
+</script>
+
+<template>
+	<BaseField v-bind="$props">
+		<PrimeTreeSelect
+			v-bind="$props"
+			v-model="model"
+		/>
+	</BaseField>
+</template>

--- a/ui/src/components/FieldTreeBox.vue
+++ b/ui/src/components/FieldTreeBox.vue
@@ -1,4 +1,4 @@
-<script setup lang="ts" generic="T extends object">
+<script setup lang="ts">
 import { computed } from "vue";
 import PrimeTreeSelect from "primevue/treeselect";
 import BaseField, { IBaseField } from "@/components/BaseField.vue";
@@ -7,7 +7,7 @@ import { ITreeOption } from "@/types/components";
 export type IFieldTreeBoxSelection = Record<string, boolean>;
 
 export interface IFieldTreeBox extends IBaseField {
-	options?: ITreeOption<T>[];
+	options?: ITreeOption[];
 	optionLabel?: string | undefined;
 	optionValue?: string | undefined;
 	disabled?: boolean;
@@ -24,7 +24,7 @@ const props = withDefaults(defineProps<IFieldTreeBox>(), {
 	options: () => [],
 });
 const emit = defineEmits(["update:modelValue"]);
-const selected = defineModel<ITreeOption<T>>("selected");
+const selected = defineModel<ITreeOption>("selected");
 const model = computed({
 	get() {
 		const { modelValue } = props;
@@ -43,7 +43,7 @@ const model = computed({
 	},
 });
 
-function getSelected(options: ITreeOption<T>[], value: string): ITreeOption<T> | undefined {
+function getSelected(options: ITreeOption[], value: string): ITreeOption | undefined {
 	const { optionValue } = props;
 	return options.find((option) => {
 		if (option[optionValue as keyof typeof option] === value) {

--- a/ui/src/models/GameOverworld.ts
+++ b/ui/src/models/GameOverworld.ts
@@ -1,0 +1,33 @@
+﻿import { IsNotEmpty, IsNotEmptyObject, IsString } from "class-validator";
+import { ViewModel } from "@/models/ViewModel";
+import { ZeldaScreen } from "@/models/ZeldaScreen";
+
+interface IOverworldSpawn {
+	SceneX: number;
+	SceneY: number;
+	X?: number;
+	Y?: number;
+	Name?: string;
+}
+
+export class GameOverworld extends ViewModel {
+	@IsString()
+	@IsNotEmpty()
+	Name = "";
+
+	@IsNotEmptyObject()
+	Spawn: IOverworldSpawn = {
+		SceneX: 112,
+		SceneY: 44,
+	};
+
+	Children: ZeldaScreen[] = [];
+
+	getConfig() {
+		return {
+			Name: this.Name,
+			Spawn: this.Spawn,
+			Children: this.Children.map((child) => child.getConfig()),
+		};
+	}
+}

--- a/ui/src/models/ZeldaScreen.ts
+++ b/ui/src/models/ZeldaScreen.ts
@@ -19,11 +19,11 @@ export interface ILoadData {
 }
 
 export class ZeldaScreen extends ViewModel {
-  @IsNumber()
-  X = 0;
+	@IsNumber()
+	X = 0;
 
-  @IsNumber()
-  Y = 0;
+	@IsNumber()
+	Y = 0;
 
 	@IsBoolean()
 	OriginTopLeft = true;
@@ -32,7 +32,7 @@ export class ZeldaScreen extends ViewModel {
 	CellSize = 16;
 
 	@IsString()
-  AccentColor = WorldColorsBrown.id;
+  	AccentColor = WorldColorsBrown.id;
 
 	@IsString()
 	GroundColor = WorldColorsTan.id;

--- a/ui/src/models/ZeldaTile.ts
+++ b/ui/src/models/ZeldaTile.ts
@@ -1,4 +1,4 @@
-﻿import { Allow, IsArray, IsObject, IsString } from "class-validator";
+﻿import { Allow, IsArray, IsNumber, IsObject, IsString } from "class-validator";
 import { getNameById } from "@/enums/helper";
 import {
 	Tiles,
@@ -76,7 +76,7 @@ import { type IZeldaEnum } from "@/types/components";
 import { isEmpty } from "@/utils/common";
 import { replaceColors } from "@/utils/zelda";
 
-const TransitionTypes = [TilesTransition, TilesDoor];
+const TransitionTypes = [TilesTransition.name, TilesDoor.name];
 function makeTargets(item: IZeldaEnum, Value?: IZeldaEnum) {
 	return ZeldaTargetColor.create({
 		Value,
@@ -222,6 +222,14 @@ export class ZeldaTile extends ViewModel {
 	@ModelTransform(() => ZeldaScreen)
 	Transition?: ZeldaScreen;
 
+	// This is only used for transitions... we need to offset their world position
+	@IsNumber()
+	OffsetX?: number;
+
+	// This is only used for transitions... we need to offset their world position
+	@IsNumber()
+	OffsetY?: number;
+
 	@Allow()
 	TileType?: IZeldaEnum;
 
@@ -231,11 +239,11 @@ export class ZeldaTile extends ViewModel {
 	}
 
 	get isDoor() {
-		return this.Type === TilesDoor;
+		return this.Type.name === TilesDoor.name;
 	}
 
 	get isTransition() {
-		return TransitionTypes.indexOf(this.Type) !== -1;
+		return TransitionTypes.indexOf(this.Type.name) !== -1;
 	}
 
 	/**
@@ -335,6 +343,9 @@ export class ZeldaTile extends ViewModel {
 					"cells",
 					"totalRows",
 					"totalColumns",
+					"_name",
+					"OriginTopLeft",
+					"CellSize",
 				],
 			}) ?? ZeldaScreen.create();
 			if (isEmpty(transition.Template)) {

--- a/ui/src/models/ZeldaTileCell.ts
+++ b/ui/src/models/ZeldaTileCell.ts
@@ -7,12 +7,12 @@ import { ILoadData, ZeldaScreen } from "@/models/ZeldaScreen";
 import { ZeldaTile } from "@/models/ZeldaTile";
 
 export class ZeldaTileCell extends ViewModel {
-  @IsArray()
-  Coordinates: number[] = [];
+	@IsArray()
+	Coordinates: number[] = [];
 
-  @IsRequired()
-  @IsString()
-  Name = "";
+	@IsRequired()
+	@IsString()
+	Name = "";
 
 	[Parent]?: ZeldaScreen;
 
@@ -60,8 +60,9 @@ export class ZeldaTileCell extends ViewModel {
 			const tileType = tile.getTypeKey();
 			const config = tile.getConfig();
 			const cellSize = grid?.CellSize || 1;
-			config.X = this.x * cellSize;
-			config.Y = this.y * cellSize;
+			const { OffsetX = 0, OffsetY = 0 } = tile;
+			config.X = (this.x + OffsetX) * cellSize;
+			config.Y = (this.y + OffsetY) * cellSize;
 			const found = Tiles.find(({ Type }) => Type === tileType);
 			if (found) {
 				found.Children.push(config);

--- a/ui/src/models/ZeldaWorldObject.ts
+++ b/ui/src/models/ZeldaWorldObject.ts
@@ -12,6 +12,8 @@ export interface IZeldaWorldObjectConfig {
 	Type?: string;
 	X: number;
 	Y: number;
+	OffsetX?: number;
+	OffsetY?: number;
 	Colors?: string[];
 }
 
@@ -72,8 +74,8 @@ export class ZeldaWorldObject extends ViewModel {
   async updateImage() {
   	if (this.hasImage()) {
   		this.src = await replaceColors({
-			  colors: this.Colors,
-			  imageEnum: this.Type,
+  			colors: this.Colors,
+  			imageEnum: this.Type,
   		});
   	}
   }

--- a/ui/src/types/components.ts
+++ b/ui/src/types/components.ts
@@ -2,6 +2,7 @@
 import type { Component, HTMLAttributes, ObjectEmitsOptions } from "vue";
 // eslint-disable-next-line vue/prefer-import-from-vue
 import { UnionToIntersection } from "@vue/shared";
+import { TreeNode } from "primevue/treenode";
 
 // Taken from Vue source, as it's not exported by them...
 export type EmitFn<Options = ObjectEmitsOptions, Event extends keyof Options = keyof Options> = Options extends Array<infer V> ? (event: V, ...args: unknown[]) => void : object extends Options ? (event: string, ...args: unknown[]) => void : UnionToIntersection<{
@@ -12,6 +13,11 @@ export interface IOption {
 	id?: string | number;
 	name?: string;
 	[key: string]: unknown;
+}
+
+export interface ITreeOption<T = string> extends TreeNode {
+	children?: ITreeOption<T>[];
+	data?: T;
 }
 
 export interface IZeldaEnum extends IOption {

--- a/ui/src/views/ViewZeldaWorldBuilder.vue
+++ b/ui/src/views/ViewZeldaWorldBuilder.vue
@@ -1,191 +1,236 @@
 <template>
-	<div class="flex h-full space-x-4 p-4">
-		<article class="flex min-w-44 flex-col space-y-4">
-			<section class="flex space-x-2">
-				<FieldTreeBox
-					v-model:selected="selectedScreen"
-					:model-value="selectedScreen?.key"
-					:options="overworldRecords"
-					:value-only="false"
-					label-align="top"
-					label="Screens"
-					option-label="Name"
-					class="flex-1"
-				/>
-				<BaseButton
-					:icon="IconAdd"
-					title="Add Screen"
-					@click="onClickNewButton"
-				/>
-			</section>
-			<FieldCheckbox
-				v-model="showGridLines"
-				label="Grid Lines"
-			/>
-			<BaseCard
-				title="Screen Coordinates"
-				class="bp-2 vertical"
-			>
-				<FieldText
-					v-model="gridRecord.Name"
-					label="Name"
-				/>
-				<section class="flex space-x-2">
-					<FieldNumber
-						v-model="gridRecord.X"
-						label="X"
-						label-width="auto"
-						input-width="w-12"
-						width="w-28"
-					/>
-					<FieldNumber
-						v-model="gridRecord.Y"
-						label="Y"
-						label-width="auto"
-						input-width="w-12"
-						width="w-28"
-					/>
-				</section>
-				<FieldCheckbox
-					v-model="gridRecord.OriginTopLeft"
-					label="Origin Top Left"
-				/>
-				<FieldNumber
-					v-model="gridRecord.CellSize"
-					label="Cell Size"
-				/>
-			</BaseCard>
-			<BaseCard
-				title="Colors"
-				class="bp-2 vertical"
-			>
-				<FieldWorldColors
-					v-model="gridRecord.GroundColor"
-					label="Ground"
-					label-cls="w-12"
-					width="w-28"
-				/>
-				<FieldWorldColors
-					v-model="gridRecord.AccentColor"
-					label="Accent"
-					label-cls="w-12"
-					width="w-28"
-				/>
-			</BaseCard>
-			<section class="ml-auto">
-				<BaseButton
-					text="Save"
-					class="default mr-2 rounded"
-					@click="onClickSaveBtn"
-				/>
-				<BaseButton
-					text="Load"
-					class="default rounded"
-					@click="onClickLoadBtn"
-				/>
-				<input
-					v-show="false"
-					ref="fileInputEl"
-					type="file"
-					@change="onChangeLoadFile"
-				>
-			</section>
-		</article>
+	<article class="flex h-full space-x-4 p-4">
 		<TileGrid
 			v-model:selected-cell="selectedCell"
 			:cells="selectedScreen?.cells"
-			:total-columns="gridRecord.totalColumns"
-			:total-rows="gridRecord.totalRows"
+			:total-columns="selectedScreen?.totalColumns ?? 11"
+			:total-rows="selectedScreen?.totalRows ?? 16"
 			:style="getCellColor()"
 			:class="gridCls"
 			@replace-cell="onReplaceCell"
 		/>
-		<article class="flex flex-col">
-			<section class="w-72 flex-1 space-y-2 overflow-auto">
-				<template v-if="selectedTile">
-					<BaseCard
-						class="vertical bp-2"
-						title="Tile"
+		<section class="flex min-w-80 flex-col space-y-4">
+			<article class="flex flex-col space-y-4">
+				<section class="flex w-full space-x-2 bg-white py-2">
+					<BaseButton
+						text="Save"
+						:icon="IconSave"
+						@click="onClickSaveBtn"
+					/>
+					<BaseButton
+						text="Load"
+						:icon="IconUploadFile"
+						@click="onClickLoadBtn"
+					/>
+					<FieldCheckbox
+						v-model="showGridLines"
+						label="Grid Lines"
+					/>
+					<input
+						v-show="false"
+						ref="fileInputEl"
+						type="file"
+						@change="onChangeLoadFile"
 					>
-						<div class="flex justify-between">
-							<FieldComboBox
-								v-model="selectedTile.Type"
-								:options="Tiles"
-								:value-only="false"
-								option-label="displayName"
-								label-position="top"
-								label="Type"
-								class="mr-2 flex-1"
-							/>
-							<div
-								v-show="showColors"
-								class="size-16 bg-blue-100"
-							>
-								<img
-									v-if="selectedTile.src"
-									:src="selectedTile.src"
-									class="size-full"
-									alt="Tile Image"
-								>
-							</div>
-						</div>
-						<template v-if="showColors">
-							<hr>
-							<FieldLabel
-								text="Replace Colors"
-								position="top"
-								class="uppercase"
-								size="medium"
-								separator=""
-							/>
-							<FieldWorldColors
-								v-for="tileColor in selectedTile.Colors"
-								:key="tileColor.Target.id"
-								v-model="tileColor.Value"
-								:label="tileColor.Target.displayName"
-								:value-only="false"
-								@update:model-value="onUpdateTileColor"
-							/>
-						</template>
-						<BaseCard
-							v-if="isTransition && selectedTile.Transition"
-							title="Transition Properties"
-							class="vertical bp-2"
-						>
-							<FieldNumber
-								v-model="selectedTile.Transition.X"
-								label="X Offset"
-								width="w-24"
-							/>
-							<FieldNumber
-								v-model="selectedTile.Transition.Y"
-								label="Y Offset"
-								width="w-24"
-							/>
-							<FieldDisplay
-								v-if="selectedTile.isDoor"
-								:value="selectedTile.Transition.Name"
-								label="Name"
-							/>
-							<FieldComboBox
-								v-if="selectedTile.isDoor"
-								v-model="selectedTile.Transition.Template"
-								label="Template"
-								required
-								option-value="value"
-								:options="ScreenTemplates"
-							/>
-							<FieldCheckbox
-								v-model="selectedTile.Transition.IsFloating"
-								label="Floating"
-							/>
-						</BaseCard>
-					</BaseCard>
-					<BaseCard
-						title="Item"
-						:expanded="false"
-						class="vertical bp-2"
-					>
+				</section>
+				<section class="flex space-x-2">
+					<FieldComboBox
+						v-model="selectedOverworld"
+						:options="overworlds"
+						:value-only="false"
+						label-align="top"
+						label="Overworld"
+						option-label="Name"
+						option-value="Name"
+						class="flex-1"
+					/>
+					<BaseButton
+						:icon="IconAdd"
+						title="Add Overworld"
+						@click="onClickAddOverworld"
+					/>
+					<BaseButton
+						v-show="!!selectedOverworld"
+						:icon="IconDelete"
+						title="Delete Overworld"
+						@click="onClickDeleteOverworld"
+					/>
+					<BaseButton
+						v-show="!!selectedOverworld"
+						:icon="IconEdit"
+						title="Edit Overworld"
+						@click="onClickEditOverworld"
+					/>
+				</section>
+				<section
+					v-if="!!selectedOverworld?.Name"
+					class="flex space-x-2"
+				>
+					<FieldComboBox
+						v-model="selectedScreen"
+						:options="selectedOverworld.Children"
+						:value-only="false"
+						label-align="top"
+						label="Screen"
+						option-label="Name"
+						option-value="Name"
+						class="flex-1"
+					/>
+					<BaseButton
+						:icon="IconAdd"
+						title="Add Screen"
+						@click="onClickNewButton"
+					/>
+					<BaseButton
+						v-show="!!selectedScreen"
+						:icon="IconDelete"
+						title="Delete Screen"
+						@click="onClickDeleteScreen"
+					/>
+				</section>
+			</article>
+			<BaseTabs
+				v-if="selectedScreen"
+				v-model:selected="selectedTab"
+				:tabs="tabs"
+				class="grow"
+			>
+				<template #content>
+					<template v-if="selectedTab === 'Screen'">
+						<FieldText
+							v-model="selectedScreen.Name"
+							label="Name"
+							class="mb-2"
+						/>
+						<section class="flex space-x-2">
+							<section class="flex flex-1 flex-col space-y-2">
+								<FieldNumber
+									v-model="selectedScreen.X"
+									label="Overworld X"
+									label-width="auto"
+									input-width="w-8"
+									width="max-w-28"
+								/>
+								<FieldNumber
+									v-model="selectedScreen.CellSize"
+									label="Cell Size"
+								/>
+								<FieldWorldColors
+									v-model="selectedScreen.AccentColor"
+									label="Accent"
+									label-cls="w-12"
+									width="w-28"
+								/>
+							</section>
+							<section class="flex flex-1 flex-col space-y-2">
+								<FieldNumber
+									v-model="selectedScreen.Y"
+									label="Overworld Y"
+									label-width="auto"
+									input-width="w-8"
+									width="max-w-28"
+								/>
+								<FieldCheckbox
+									v-model="selectedScreen.OriginTopLeft"
+									label="Origin Top Left"
+								/>
+								<FieldWorldColors
+									v-model="selectedScreen.GroundColor"
+									label="Ground"
+									label-cls="w-12"
+									width="w-28"
+								/>
+							</section>
+						</section>
+					</template>
+					<template v-else-if="selectedTab === 'Tile'">
+						<article class="flex h-full flex-col overflow-auto">
+							<section class="w-72 flex-1 space-y-2">
+								<template v-if="selectedTile">
+									<div class="flex justify-between">
+										<FieldComboBox
+											v-model="selectedTile.Type"
+											:options="Tiles"
+											:value-only="false"
+											option-label="displayName"
+											label-position="top"
+											label="Type"
+											class="mr-2 flex-1"
+										/>
+										<div
+											v-show="showColors"
+											class="size-16 bg-blue-100"
+										>
+											<img
+												v-if="selectedTile.src"
+												:src="selectedTile.src"
+												class="size-full"
+												alt="Tile Image"
+											>
+										</div>
+									</div>
+									<template v-if="showColors">
+										<hr>
+										<FieldLabel
+											text="Replace Tile Colors"
+											position="top"
+											size="medium"
+											class="!text-black"
+											separator=""
+										/>
+										<FieldWorldColors
+											v-for="tileColor in selectedTile.Colors"
+											:key="tileColor.Target.id"
+											v-model="tileColor.Value"
+											:label="tileColor.Target.displayName"
+											:value-only="false"
+											@update:model-value="onUpdateTileColor"
+										/>
+									</template>
+									<template v-if="isTransition && selectedTile.Transition">
+										<FieldNumber
+											v-model="selectedTile.Transition.X"
+											label="Transition X"
+											width="w-24"
+										/>
+										<FieldNumber
+											v-model="selectedTile.Transition.Y"
+											label="Transition Y"
+											width="w-24"
+										/>
+										<FieldNumber
+											v-model="selectedTile.OffsetX"
+											label="Position Offset X"
+											width="w-24"
+										/>
+										<FieldNumber
+											v-model="selectedTile.OffsetY"
+											label="Position Offset Y"
+											width="w-24"
+										/>
+										<FieldDisplay
+											v-if="selectedTile.isDoor"
+											:value="selectedTile.Transition.Name"
+											label="Name"
+										/>
+										<FieldComboBox
+											v-if="selectedTile.isDoor"
+											v-model="selectedTile.Transition.Template"
+											label="Template"
+											required
+											option-value="value"
+											:options="ScreenTemplates"
+										/>
+										<FieldCheckbox
+											v-model="selectedTile.Transition.IsFloating"
+											label="Floating"
+										/>
+									</template>
+								</template>
+							</section>
+						</article>
+					</template>
+					<template v-else-if="selectedTab === 'Item'">
 						<div
 							v-if="selectedItem"
 							class="flex justify-between"
@@ -194,7 +239,7 @@
 								v-model="selectedItem.Type"
 								:options="Items"
 								:value-only="false"
-								label="Type"
+								label="Item Type"
 								label-position="top"
 								class="mr-2 flex-1"
 							/>
@@ -207,13 +252,8 @@
 								>
 							</div>
 						</div>
-					</BaseCard>
-					<BaseCard
-						v-if="selectedEnemy"
-						title="Enemy"
-						:expanded="false"
-						class="vertical bp-2"
-					>
+					</template>
+					<template v-else-if="selectedTab === 'Enemy' && selectedEnemy">
 						<div class="flex items-center justify-between">
 							<div class="mr-2 flex flex-1 flex-col justify-between space-y-2">
 								<FieldComboBox
@@ -292,37 +332,47 @@
 							label="Weapon"
 							label-cls="w-14"
 						/>
-					</BaseCard>
+					</template>
 				</template>
-			</section>
-		</article>
-	</div>
+			</BaseTabs>
+		</section>
+	</article>
+	<DialogOverworld
+		v-model="showDialogOverworld"
+		:record="selectedOverworld"
+		@click-save="onClickSaveOverworld"
+		@click-cancel="onCancelOverworld"
+	/>
 </template>
 
 <script setup lang="ts">
 import { computed, reactive, ref, unref, watch } from "vue";
 import IconAdd from "@/assets/IconAdd.vue";
+import IconDelete from "@/assets/IconDelete.vue";
+import IconEdit from "@/assets/IconEdit.vue";
+import IconSave from "@/assets/IconSave.vue";
+import IconUploadFile from "@/assets/IconUploadFile.vue";
 import BaseButton from "@/components/BaseButton.vue";
-import BaseCard from "@/components/BaseCard.vue";
+import BaseTabs from "@/components/BaseTabs.vue";
 import FieldCheckbox from "@/components/FieldCheckbox.vue";
 import FieldComboBox from "@/components/FieldComboBox.vue";
 import FieldDisplay from "@/components/FieldDisplay.vue";
 import FieldLabel from "@/components/FieldLabel.vue";
 import FieldNumber from "@/components/FieldNumber.vue";
 import FieldText from "@/components/FieldText.vue";
-import FieldTreeBox from "@/components/FieldTreeBox.vue";
 import { findRecord } from "@/enums/helper";
 import { Items } from "@/enums/zelda/Items";
 import { Enemies } from "@/enums/zelda/NPCs";
 import { ScreenTemplates } from "@/enums/zelda/ScreenTemplates";
 import { Tiles } from "@/enums/zelda/Tiles";
 import { WorldColors, WorldColorsNone } from "@/enums/zelda/WorldColors";
+import { GameOverworld } from "@/models/GameOverworld";
 import { Parent } from "@/models/ViewModel";
 import { ZeldaScreen } from "@/models/ZeldaScreen";
 import { ZeldaTileCell } from "@/models/ZeldaTileCell";
-import { ITreeOption } from "@/types/components";
-import { makeArray } from "@/utils/common";
+import { makeArray, removeItem } from "@/utils/common";
 import { provideCellCopy } from "@/views/zeldaWorldBuilder/cellCopy";
+import DialogOverworld from "@/views/zeldaWorldBuilder/DialogOverworld.vue";
 import FieldWorldColors from "@/views/zeldaWorldBuilder/FieldWorldColors.vue";
 import TileGrid from "@/views/zeldaWorldBuilder/TileGrid.vue";
 
@@ -340,41 +390,39 @@ import TileGrid from "@/views/zeldaWorldBuilder/TileGrid.vue";
  */
 const fileInputEl = ref<HTMLInputElement>();
 const selectedCell = ref<ZeldaTileCell>();
+const selectedOverworld = ref();
 const showGridLines = ref(true);
-const overworldRecords = reactive<ITreeOption<ZeldaScreen>[]>([]);
-const selectedScreen = ref<ITreeOption<ZeldaScreen>>();
-const gridRecord = ref(addGridRecord());
+const showDialogOverworld = ref(false);
+const isEditOverworld = ref(false);
+const overworlds = reactive<GameOverworld[]>([]);
+const selectedScreen = ref<ZeldaScreen>();
 const isTransition = computed(() => selectedCell.value?.tile.isTransition);
 const selectedTile = computed(() => selectedCell.value?.tile);
 const selectedItem = computed(() => selectedCell.value?.item);
 const selectedEnemy = computed(() => selectedCell.value?.enemy);
 const showColors = computed(() => !isTransition.value && selectedTile.value?.hasImage());
+const tabs = ref(["Screen"]);
+const selectedTab = ref(tabs.value[0]);
 const gridCls = computed(() => {
 	return {
-		"grid-origin-top-left": gridRecord.value.OriginTopLeft,
+		"grid-origin-top-left": selectedScreen.value?.OriginTopLeft,
 		"grid-show-lines": showGridLines.value,
 	};
 });
 
-function addGridRecord(config = {}) {
-	const record = ZeldaScreen.create({
+function addScreen(config = {}) {
+	selectedScreen.value = ZeldaScreen.create({
 		totalRows: 11,
 		totalColumns: 16,
 		...config,
 	}, {
 		init: true,
 	});
-	selectedScreen.value = {
-		key: record.Name,
-		label: record.Name,
-		data: record,
-	};
-	overworldRecords.push(selectedScreen.value);
-	return record;
+	selectedOverworld.value.Children.push(selectedScreen.value);
 }
 
 function getCellColor() {
-	const found = findRecord(WorldColors, gridRecord.value.GroundColor);
+	const found = findRecord(WorldColors, selectedScreen.value?.GroundColor);
 	if (found === WorldColorsNone || !found) {
 		return "";
 	}
@@ -393,29 +441,47 @@ function onReplaceCell({ indices, replacement }: { indices: number | number[], r
 	indices = makeArray(indices);
 	// Make sure we update the selection with the replacement
 	selectedCell.value = replacement;
-	const $gridRecord = unref(gridRecord);
-	indices.forEach((idx) => {
-		const record = $gridRecord.cells[idx];
-		const clone = replacement.clone({
-			options: {
-				init: true,
-			},
+	const $selectedScreen = unref(selectedScreen);
+	if ($selectedScreen) {
+		indices.forEach((idx) => {
+			const record = $selectedScreen.cells[idx];
+			const clone = replacement.clone({
+				options: {
+					init: true,
+				},
+			});
+			clone.Coordinates = record.Coordinates;
+			// Replace the parent, as it gets cloned incorrectly
+			clone[Parent] = $selectedScreen!;
+			$selectedScreen.cells[idx] = clone;
 		});
-		clone.Coordinates = record.Coordinates;
-		// Replace the parent, as it gets cloned incorrectly
-		clone[Parent] = $gridRecord!;
-		$gridRecord.cells[idx] = clone;
-	});
+	}
 }
 
 function onClickLoadBtn() {
 	fileInputEl.value?.click();
 }
 
+function onClickAddOverworld() {
+	selectedOverworld.value = GameOverworld.create();
+	showDialogOverworld.value = true;
+	isEditOverworld.value = false;
+}
+
+function onClickEditOverworld() {
+	showDialogOverworld.value = true;
+	isEditOverworld.value = true;
+}
+
+function onClickDeleteOverworld() {
+	removeItem(overworlds, selectedOverworld.value);
+	selectedOverworld.value = undefined;
+}
+
 function onChangeLoadFile() {
 	const reader = new FileReader();
 	reader.addEventListener("load", () => {
-		gridRecord.value.loadFileData(JSON.parse(reader.result as string));
+		selectedScreen.value?.loadFileData(JSON.parse(reader.result as string));
 	});
 	const [file] = fileInputEl.value?.files ?? [];
 	if (file) {
@@ -425,29 +491,70 @@ function onChangeLoadFile() {
 
 // TODOJEF: Need to make this save all files to overworld or redesign the files, so we can have 1 overworld file
 function onClickSaveBtn() {
+	const configs: Record<string, object> = {};
+	overworlds.forEach((overworld) => configs[overworld.Name] = overworld.getConfig());
 	// TODO: Move this logic to a utility function
-	const contents = new Blob([JSON.stringify(gridRecord.value.getConfig())], {
+	const contents = new Blob([JSON.stringify(configs)], {
 		type: "application/json",
 	});
 	const tempEl = document.createElement("a");
-	tempEl.download = `${gridRecord.value.X}${gridRecord.value.Y}.json`;
+	tempEl.download = "game.json";
 	tempEl.href = window.URL.createObjectURL(contents);
 	tempEl.click();
 }
 
 function onClickNewButton() {
-	addGridRecord({
-		Name: "TEMPORARY NAME",
+	addScreen({
+		Name: "Temporary Name",
 	});
 }
 
-watch(selectedScreen, ($selectedScreen) => {
+function onClickDeleteScreen() {
+	removeItem(selectedOverworld.value.Children, selectedScreen.value);
+	selectedScreen.value = undefined;
+}
+
+function onCancelOverworld() {
+	if (isEditOverworld.value) {
+		return;
+	}
+	selectedOverworld.value = undefined;
+}
+
+function onClickSaveOverworld(viewRecord: GameOverworld) {
+	selectedOverworld.value = viewRecord;
+	if (!isEditOverworld.value) {
+		overworlds.push(viewRecord);
+	}
+}
+
+watch(selectedOverworld, () => {
 	selectedCell.value = undefined;
-	gridRecord.value = $selectedScreen!.data!;
+	selectedScreen.value = undefined;
 });
 
-watch(() => gridRecord.value?.OriginTopLeft, () => {
-	gridRecord.value?.cells.forEach((cell) => cell.Coordinates = [cell.x, 10 - cell.y]);
+watch(selectedScreen, () => {
+	selectedCell.value = undefined;
+});
+
+watch(() => selectedScreen.value?.OriginTopLeft, ($originTopLeft) => {
+	const cells = selectedScreen.value?.cells;
+	if ($originTopLeft && cells?.[0].Coordinates[1] !== 0 || !$originTopLeft && cells?.[0].Coordinates[1] !== 10) {
+		selectedScreen.value?.cells.forEach((cell) => cell.Coordinates = [cell.x, 10 - cell.y]);
+	}
+});
+
+watch(selectedCell, ($selectedCell, $previousValue) => {
+	if ($selectedCell && !$previousValue) {
+		tabs.value.push("Tile", "Item", "Enemy");
+		selectedTab.value = "Tile";
+	}
+	else if (!$selectedCell) {
+		removeItem(tabs.value, "Tile");
+		removeItem(tabs.value, "Item");
+		removeItem(tabs.value, "Enemy");
+		selectedTab.value = "Screen";
+	}
 });
 
 provideCellCopy();

--- a/ui/src/views/zeldaWorldBuilder/DialogOverworld.vue
+++ b/ui/src/views/zeldaWorldBuilder/DialogOverworld.vue
@@ -1,0 +1,64 @@
+<script setup lang="ts">
+import { ref, unref } from "vue";
+import IconSave from "@/assets/IconSave.vue";
+import BaseButton from "@/components/BaseButton.vue";
+import BaseDialog from "@/components/BaseDialog.vue";
+import FieldComboBox from "@/components/FieldComboBox.vue";
+import FieldNumber from "@/components/FieldNumber.vue";
+import FieldText from "@/components/FieldText.vue";
+import { GameOverworld } from "@/models/GameOverworld";
+
+const emit = defineEmits(["click-save"]);
+const viewRecord = defineModel<GameOverworld>("record", {
+	default: GameOverworld.create(),
+});
+const rootCmp = ref<InstanceType<typeof BaseDialog>>();
+
+async function onClickSave() {
+	const $viewRecord = unref(viewRecord);
+	if (await $viewRecord.isValid()) {
+		emit("click-save", viewRecord.value);
+		rootCmp.value?.close();
+	}
+}
+</script>
+
+<template>
+	<BaseDialog
+		ref="rootCmp"
+		title="Add Overworld"
+		@keydown.enter="onClickSave"
+	>
+		<template #body>
+			<section class="flex flex-col space-y-2">
+				<FieldText
+					v-model="viewRecord.Name"
+					label="Name"
+					auto-focus
+				/>
+				<FieldNumber
+					v-model="viewRecord.Spawn.SceneX"
+					label="Spawn X"
+				/>
+				<FieldNumber
+					v-model="viewRecord.Spawn.SceneY"
+					label="Spawn Y"
+				/>
+				<FieldComboBox
+					v-model="viewRecord.Spawn.Name"
+					:options="viewRecord.Children"
+					option-value="Name"
+					option-label="Name"
+					label="Spawn Screen"
+				/>
+			</section>
+		</template>
+		<template #afterCancel>
+			<BaseButton
+				text="Save"
+				:icon="IconSave"
+				@click="onClickSave"
+			/>
+		</template>
+	</BaseDialog>
+</template>


### PR DESCRIPTION
- Adding FieldTreeBox.vue to wrap PrimeVue's TreeSelect component
- Changing to use TreeSelect for the screen tile in ZeldaWorldBuilder
- Adding BaseTabs.vue core component
- Adding GameOverworld.ts class
- Adding DialogOverworld.vue to configure the GameOverworld instance
- Reworking the UI, so the overworld is the parent selector that contains the screens
- Fixing issue in BaseDialog.vue where PrimeVue doesn't report a cancel vs a close
- Adding ability to auto focus FieldText.vue
- Adding validation logic to ViewModel.ts
- Fixing issue in ZeldaTile.ts where the proxies were being checked against the raw objects incorrectly
- Adding ability to offset Transitions by x/y coords
- Adding ability to delete overworlds and screens