### PR TITLE
feat: Add downloading models

### DIFF
--- a/linkedIn/main.js
+++ b/linkedIn/main.js
@@ -1,7 +1,7 @@
 /**
  * In order to use this, go to about:debugging#/runtime/this-firefox and load the manifest.json file as the Temporary Add-on
  */
-const MatchRegex = /Viewed|Applied/;
+const MatchRegex = /Viewed|Applied|Promoted/;
 const CompaniesRegex = /Understanding Recruitment|Umicas|Canonical|B4Corp|Wesley Finance|Phoenix Recruitment|Globe Life|Childhood Cancer Society|Mobius Ventures|Breezy Talent|Find Next Hire|Timely Find|Finding Candidate|Jobs via Dice|Geico|Novum Global|Pragmatike|Energy Jobline|JTek Software Solutions|Software Technology Inc|Get It|Actalent|Patterned Learning|G2i|SideRamp|DataAnnotation|Veeva Systems|Aha!|HireMeFast|Team Remotely|Recruiting from Scratch|myGwork|Jerry|RemoteWorker|ClickJobs\.io|Varsity Tutors|Ascendion/i;
 const Today = new Date();
 const OneWeek = 604800000;

--- a/package-lock.json
+++ b/package-lock.json
@@ -9129,6 +9129,12 @@
         "node": ">= 12"
       }
     },
+    "node_modules/client-zip": {
+      "version": "2.4.6",
+      "resolved": "https://registry.npmjs.org/client-zip/-/client-zip-2.4.6.tgz",
+      "integrity": "sha512-e7t1u14h/yT0A12qBwFsaus8UZZ8+MCaNAEn/z53mrukLq/LFcKX7TkbntAppGu8he2p8pz9vc5NEGE/h4ohlw==",
+      "license": "MIT"
+    },
     "node_modules/cliui": {
       "version": "8.0.1",
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
@@ -28748,7 +28754,7 @@
     },
     "ui": {
       "name": "@incutonez/ui",
-      "version": "2.8.0",
+      "version": "2.10.0",
       "dependencies": {
         "@faker-js/faker": "^9.4.0",
         "@material-symbols/svg-400": "^0.28.1",
@@ -28761,6 +28767,7 @@
         "@vueuse/core": "^12.5.0",
         "class-transformer": "^0.5.1",
         "class-validator": "^0.14.1",
+        "client-zip": "^2.4.6",
         "glob": "^11.0.1",
         "highlight.js": "^11.11.1",
         "just-clone": "^6.2.0",

--- a/ui/package.json
+++ b/ui/package.json
@@ -21,6 +21,7 @@
     "@vueuse/core": "^12.5.0",
     "class-transformer": "^0.5.1",
     "class-validator": "^0.14.1",
+    "client-zip": "^2.4.6",
     "glob": "^11.0.1",
     "highlight.js": "^11.11.1",
     "just-clone": "^6.2.0",

--- a/ui/src/assets/theme/select/index.js
+++ b/ui/src/assets/theme/select/index.js
@@ -3,7 +3,7 @@ export default {
 		class: [
 			// Display and Position
 			"inline-flex",
-			"relative max-h-8",
+			"relative max-h-9",
 
 			// Shape
 			"rounded-md",

--- a/ui/src/components/BaseTabs.vue
+++ b/ui/src/components/BaseTabs.vue
@@ -21,11 +21,11 @@ function getTabCls(tab: string) {
 
 <template>
 	<article class="flex flex-col overflow-hidden">
-		<section class="flex h-8">
+		<section class="flex overflow-auto">
 			<div
 				v-for="tab in tabs"
 				:key="tab"
-				class="flex h-full cursor-pointer items-center rounded-t border border-b-0 border-gray-b px-3 text-sm hover:bg-sky-200 [&:nth-child(n+2)]:border-l-0"
+				class="flex h-8 cursor-pointer items-center rounded-t border border-b-0 border-gray-b px-3 text-sm hover:bg-sky-200 [&:nth-child(n+2)]:border-l-0"
 				:class="getTabCls(tab)"
 				@click="onClickTab(tab)"
 			>

--- a/ui/src/style.css
+++ b/ui/src/style.css
@@ -1,6 +1,10 @@
 @import url('https://fonts.googleapis.com/css2?family=Open+Sans:ital,wght@0,300..800;1,300..800&display=swap');
 @import "tailwindcss";
 
+/* Turning off the prefers-color-scheme mode
+ * https://tailwindcss.com/docs/dark-mode#toggling-dark-mode-manually */
+@custom-variant dark (&:where(.dark, .dark *));
+
 @theme {
     --color-select-200: var(--color-sky-200);
     --color-select-600: var(--color-sky-600);

--- a/ui/src/utils/common.ts
+++ b/ui/src/utils/common.ts
@@ -9,6 +9,7 @@ export { snakeCase, camelCase } from "lodash-es";
 
 export const capitalCase = capitalize;
 
+const SplitCapitalizeRe = /[a-z]+|[A-Z]+[a-z]*/g;
 // TODO: Get i18n string from somewhere
 const DateLong = Intl.DateTimeFormat("en-us", {
 	month: "2-digit",
@@ -56,6 +57,13 @@ export function isObject(value?: unknown): value is object {
 	return lodashIsObject(value);
 }
 
+export function splitCapitalize(word: string) {
+	const matches = word.match(SplitCapitalizeRe);
+	if (matches?.length) {
+		return matches.reduce((output, item) => output + capitalize(item), "");
+	}
+}
+
 export function pluck<T = unknown>(items: object[], keys: string | string[]) {
 	const collection: T[] = [];
 	if (Array.isArray(keys)) {
@@ -97,8 +105,7 @@ export function getAvatar() {
 	return Avatars[index];
 }
 
-export function downloadFile(blob: Blob, name = "download") {
-	const extension = MimeTypes.extension(blob.type);
+export function downloadFile(blob: Blob, name = "download", extension = MimeTypes.extension(blob.type)) {
 	if (!extension) {
 		return;
 	}

--- a/ui/src/views/ViewSequelizeModelBuilder.vue
+++ b/ui/src/views/ViewSequelizeModelBuilder.vue
@@ -108,8 +108,6 @@ ${fields.join("\n\n")}
 	};
 }
 
-// TODOJEF: Need to add imports for interface/classes
-// TODOJEF: It'd be nice if single file download didn't do all the imports
 function makeField({ nullable, key, type, fk, primaryKey, hasOne, hasMany }: IModelField): string {
 	const column = [];
 	const nullableSymbol = nullable ? "?" : "";


### PR DESCRIPTION
- Adding ability to download models as either a single file or multiple files
- Changing logic for including imports... downloading multiple files has imports, but single file has no need for imports
- Fixing how CapitalCase works
- Fixing issue with dark mode being preferred in tailwind
- Adding interface support as output type
- Fixing horizontal scroll issue in BaseTabs.vue
- Fixing FieldComboBox height issue
- Fixing issue with array of primitives splitting out each index as a field... now properly makes the array type a `primitive[]`
- Fixing issue with empty arrays throwing an error... now displays as `unknown[]`
- Fixing issue with some associations ending in `Id` and having a double `_id_id` in the output... now strips the `Id` and creates the model name without it